### PR TITLE
Update action steps version

### DIFF
--- a/.github/workflows/release-MAAS-PlanScoreCard-v156.yml
+++ b/.github/workflows/release-MAAS-PlanScoreCard-v156.yml
@@ -11,7 +11,7 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '4/1/2023'
+        default: '4/1/2025'
 
 jobs:
   build:
@@ -26,13 +26,19 @@ jobs:
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
+    - name: Get Current Date
+      id: currentDate
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      with:
+        format: "MM/DD/YYYY"
+
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
       
     - name: Navigate to Workspace
       run: cd $GITHUB_WORKSPACE
@@ -94,7 +100,7 @@ jobs:
         "NORMALIZED_FILE_PATH=$($normalizedFilePath)" >> $env:GITHUB_OUTPUT
 
     - name: Create Release
-      uses: softprops/action-gh-release@v0.1.13
+      uses: softprops/action-gh-release@v2.0.9
       with:
         name: V15.6-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
         tag_name: V15.6-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
@@ -104,5 +110,5 @@ jobs:
         body: |
           This is an official release of the **`${{ env.PROJECT_NAME }}`** project.
           Supported Eclipse version: `v15.6`.
-          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.update_assembly_info.outputs.CURRENT_DATE }}`.
+          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.currentDate.outputs.time }}`.
         files: ${{ steps.zip_release.outputs.NORMALIZED_FILE_PATH }}

--- a/.github/workflows/release-MAAS-PlanScoreCard-v161.yml
+++ b/.github/workflows/release-MAAS-PlanScoreCard-v161.yml
@@ -11,7 +11,7 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '4/1/2023'
+        default: '4/1/2025'
 
 jobs:
   build:
@@ -26,13 +26,19 @@ jobs:
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
+    - name: Get Current Date
+      id: currentDate
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      with:
+        format: "MM/DD/YYYY"
+
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
       
     - name: Navigate to Workspace
       run: cd $GITHUB_WORKSPACE
@@ -106,7 +112,7 @@ jobs:
         "NORMALIZED_FILE_PATH=$($normalizedFilePath)" >> $env:GITHUB_OUTPUT
 
     - name: Create Release
-      uses: softprops/action-gh-release@v0.1.13
+      uses: softprops/action-gh-release@v2.0.9
       with:
         name: V16.1-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
         tag_name: V16.1-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
@@ -116,5 +122,5 @@ jobs:
         body: |
           This is an official release of the **`${{ env.PROJECT_NAME }}`** project.
           Supported Eclipse version: `v16.1`.
-          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.update_assembly_info.outputs.CURRENT_DATE }}`.
+          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.currentDate.outputs.time }}`.
         files: ${{ steps.zip_release.outputs.NORMALIZED_FILE_PATH }}

--- a/.github/workflows/release-MAAS-PlanScoreCard-v170.yml
+++ b/.github/workflows/release-MAAS-PlanScoreCard-v170.yml
@@ -11,7 +11,7 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '4/1/2023'
+        default: '4/1/2025'
 
 jobs:
   build:
@@ -26,13 +26,19 @@ jobs:
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
+    - name: Get Current Date
+      id: currentDate
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      with:
+        format: "MM/DD/YYYY"
+
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
       
     - name: Navigate to Workspace
       run: cd $GITHUB_WORKSPACE
@@ -108,7 +114,7 @@ jobs:
         "NORMALIZED_FILE_PATH=$($normalizedFilePath)" >> $env:GITHUB_OUTPUT
 
     - name: Create Release
-      uses: softprops/action-gh-release@v0.1.13
+      uses: softprops/action-gh-release@v2.0.9
       with:
         name: V17.0-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
         tag_name: V17.0-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
@@ -118,5 +124,5 @@ jobs:
         body: |
           This is an official release of the **`${{ env.PROJECT_NAME }}`** project.
           Supported Eclipse version: `v17.0`.
-          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.update_assembly_info.outputs.CURRENT_DATE }}`.
+          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.currentDate.outputs.time }}`.
         files: ${{ steps.zip_release.outputs.NORMALIZED_FILE_PATH }}

--- a/.github/workflows/release-MAAS-PlanScoreCard-v180.yml
+++ b/.github/workflows/release-MAAS-PlanScoreCard-v180.yml
@@ -11,7 +11,7 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '4/1/2023'
+        default: '4/1/2025'
 
 jobs:
   build:
@@ -26,13 +26,19 @@ jobs:
       BUILD_NUMBER: ${{ github.run_number }}
 
     steps:
+    - name: Get Current Date
+      id: currentDate
+      uses: Kaven-Universe/github-action-current-date-time@v1
+      with:
+        format: "MM/DD/YYYY"
+
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
       
     - name: Navigate to Workspace
       run: cd $GITHUB_WORKSPACE
@@ -108,7 +114,7 @@ jobs:
         "NORMALIZED_FILE_PATH=$($normalizedFilePath)" >> $env:GITHUB_OUTPUT
  
     - name: Create Release
-      uses: softprops/action-gh-release@v0.1.13
+      uses: softprops/action-gh-release@v2.0.9
       with:
         name: V18.0-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
         tag_name: V18.0-${{ steps.update_assembly_info.outputs.RELEASE_NAME }}
@@ -118,5 +124,5 @@ jobs:
         body: |
           This is an official release of the **`${{ env.PROJECT_NAME }}`** project.
           Supported Eclipse version: `v18.0`.
-          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.update_assembly_info.outputs.CURRENT_DATE }}`.
+          The generated dll is valid until `${{ github.event.inputs.dateInput }}`, and generated on `${{ steps.currentDate.outputs.time }}`.
         files: ${{ steps.zip_release.outputs.NORMALIZED_FILE_PATH }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# Visual Studio Code settings
+.vscode/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
Update used github action steps version to newer ones, to avoid obsolete command usage.
Also update the release text with valid date stamp. 